### PR TITLE
Photo Edit Feature adjust and filters

### DIFF
--- a/camPod/Classes/EditPhoto/VIewModel/PhotoEditorViewModel.swift
+++ b/camPod/Classes/EditPhoto/VIewModel/PhotoEditorViewModel.swift
@@ -26,37 +26,32 @@ public class PhotoEditorViewModel {
     //swiftlint:enable all
         switch selectedFilter {
         case 0:
-            print("camShare")
             if #available(iOS 13.0, *) {
                 let result = createCamShareCustionFilter(image: image)
                 view?.updateImageView(image: result)
             }
         case 1:
-            print("Cold")
             if #available(iOS 13.0, *) {
                 let result = createColdFilter(image: image)
                 view?.updateImageView(image: result)
             }
         case 2:
-            print("Vivid Cold")
             if #available(iOS 13.0, *) {
                 let result = createColdVividFilter(image: image)
                 view?.updateImageView(image: result)
             }
         case 3:
-            print("")
             if #available(iOS 13.0, *) {
                 let result = createWarmFilter(image: image)
                 view?.updateImageView(image: result)
             }
         case 4:
-            print("")
             if #available(iOS 13.0, *) {
                 let result = createWarmVididFilter(image: image)
                 view?.updateImageView(image: result)
             }
         default:
-            print("")
+            break
         }
     }
 

--- a/camPod/Classes/EditPhoto/VIewModel/PhotoEditorViewModel.swift
+++ b/camPod/Classes/EditPhoto/VIewModel/PhotoEditorViewModel.swift
@@ -21,8 +21,9 @@ public class PhotoEditorViewModel {
     func changeFilter(index: Int) {
         currentFilterIndex = index
     }
-
+    //swiftlint:disable all
     func applyPredefinedFilter(image: UIImage, selectedFilter: Int) {
+    //swiftlint:enable all
         switch selectedFilter {
         case 0:
             print("camShare")

--- a/camPod/Classes/EditPhoto/VIewModel/PhotoEditorViewModel.swift
+++ b/camPod/Classes/EditPhoto/VIewModel/PhotoEditorViewModel.swift
@@ -1,0 +1,153 @@
+//
+//  PhotoEditorViewModel.swift
+//  camPod
+//
+//  Created by Janco Erasmus on 2020/04/21.
+//
+
+import Foundation
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+public class PhotoEditorViewModel {
+
+    var view: PhotoEditorViewType?
+    var currentFilterIndex = 0
+
+    public init() {
+
+    }
+
+    func changeFilter(index: Int) {
+        currentFilterIndex = index
+    }
+
+    func applyPredefinedFilter(image: UIImage, selectedFilter: Int) {
+        switch selectedFilter {
+        case 0:
+            print("camShare")
+            if #available(iOS 13.0, *) {
+                let result = createCamShareCustionFilter(image: image)
+                view?.updateImageView(image: result)
+            }
+        case 1:
+            print("Cold")
+            if #available(iOS 13.0, *) {
+                let result = createColdFilter(image: image)
+                view?.updateImageView(image: result)
+            }
+        case 2:
+            print("Vivid Cold")
+            if #available(iOS 13.0, *) {
+                let result = createColdVividFilter(image: image)
+                view?.updateImageView(image: result)
+            }
+        case 3:
+            print("")
+            if #available(iOS 13.0, *) {
+                let result = createWarmFilter(image: image)
+                view?.updateImageView(image: result)
+            }
+        case 4:
+            print("")
+            if #available(iOS 13.0, *) {
+                let result = createWarmVididFilter(image: image)
+                view?.updateImageView(image: result)
+            }
+        default:
+            print("")
+        }
+    }
+
+    @available(iOS 13.0, *)
+    func createCamShareCustionFilter(image: UIImage) -> CIImage{
+        var ciImageCandidate = CIImage()
+        if let imageData = image.jpegData(compressionQuality: 1) {
+            ciImageCandidate = CIImage(data: imageData)!
+        }
+
+        let filter = CIFilter.temperatureAndTint()
+        filter.neutral = CIVector(x: 6500, y: 0)
+        filter.targetNeutral = CIVector(x: 7800, y: 0)
+        filter.inputImage = ciImageCandidate
+        var result = filter.outputImage
+        let secondFilter = CIFilter.vibrance()
+        secondFilter.amount = -0.5
+        secondFilter.inputImage = result
+        result = secondFilter.outputImage
+        let thirdFilter = CIFilter.vignette()
+        thirdFilter.radius = 1
+        thirdFilter.intensity = 0.5
+        thirdFilter.inputImage = result
+        result = thirdFilter.outputImage
+        return result!
+    }
+
+    @available(iOS 13.0, *)
+    func createColdFilter(image: UIImage) -> CIImage {
+        var ciImageCandidate = CIImage()
+        if let imageData = image.jpegData(compressionQuality: 1) {
+            ciImageCandidate = CIImage(data: imageData)!
+        }
+
+        let filter = CIFilter.temperatureAndTint()
+        filter.neutral = CIVector(x: 6500, y: 0)
+        filter.targetNeutral = CIVector(x: 9000, y: 0)
+        filter.inputImage = ciImageCandidate
+        let result = filter.outputImage
+        return result!
+    }
+
+    @available(iOS 13.0, *)
+    func createColdVividFilter(image: UIImage) -> CIImage {
+        var ciImageCandidate = CIImage()
+        if let imageData = image.jpegData(compressionQuality: 1) {
+            ciImageCandidate = CIImage(data: imageData)!
+        }
+
+        let filter = CIFilter.temperatureAndTint()
+        filter.neutral = CIVector(x: 6500, y: 0)
+        filter.targetNeutral = CIVector(x: 9000, y: 0)
+        filter.inputImage = ciImageCandidate
+        var result = filter.outputImage
+        let secondFilter = CIFilter.vibrance()
+        secondFilter.amount = 1.25
+        secondFilter.inputImage = result
+        result = secondFilter.outputImage
+        return result!
+    }
+
+    @available(iOS 13.0, *)
+    func createWarmFilter(image: UIImage) -> CIImage {
+        var ciImageCandidate = CIImage()
+        if let imageData = image.jpegData(compressionQuality: 1) {
+            ciImageCandidate = CIImage(data: imageData)!
+        }
+
+        let filter = CIFilter.temperatureAndTint()
+        filter.neutral = CIVector(x: 6500, y: 0)
+        filter.targetNeutral = CIVector(x: 4000, y: 0)
+        filter.inputImage = ciImageCandidate
+        let result = filter.outputImage
+        return result!
+    }
+
+    @available(iOS 13.0, *)
+    func createWarmVididFilter(image: UIImage) -> CIImage {
+        var ciImageCandidate = CIImage()
+        if let imageData = image.jpegData(compressionQuality: 1) {
+            ciImageCandidate = CIImage(data: imageData)!
+        }
+
+        let filter = CIFilter.temperatureAndTint()
+        filter.neutral = CIVector(x: 6500, y: 0)
+        filter.targetNeutral = CIVector(x: 4000, y: 0)
+        filter.inputImage = ciImageCandidate
+        var result = filter.outputImage
+        let secondFilter = CIFilter.vibrance()
+        secondFilter.amount = -0.9
+        secondFilter.inputImage = result
+        result = secondFilter.outputImage
+        return result!
+    }
+}

--- a/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
+++ b/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
@@ -242,7 +242,7 @@ import CoreImage.CIFilterBuiltins
             present(alert, animated: true, completion: nil)
         }
     }
-    
+
     func filterChanged() {
         for index in 0..<uiButtonCollection.count {
             if index == currentFilterIndex {

--- a/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
+++ b/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
@@ -1,0 +1,324 @@
+//
+//  PhotoEditingViewController.swift
+//  camPod
+//
+//  Created by Janco Erasmus on 2020/04/21.
+//
+
+import UIKit
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+@objcMembers public class PhotoEditingViewController: UIViewController {
+
+    @IBOutlet var inEditPhotoImageView: UIImageView!
+    @IBOutlet var currentFilterLabel: UILabel!
+    @IBOutlet var firstFilterButton: UIButton!
+    @IBOutlet var secondFilterButton: UIButton!
+    @IBOutlet var thirdFilterButton: UIButton!
+    @IBOutlet var fourthFIlterButton: UIButton!
+    @IBOutlet var fifthFilterButton: UIButton!
+    @IBOutlet var applyAmountSlider: UISlider!
+    @IBOutlet var sliderValueLabel: UILabel!
+    @IBOutlet var adjustButton: UIBarButtonItem!
+    @IBOutlet var filterButton: UIBarButtonItem!
+    @IBOutlet var cropButton: UIBarButtonItem!
+    
+    @objc public var inEditPhoto = UIImage(named: "image-2")!
+    @objc public var name = ""
+
+    var viewModel = PhotoEditorViewModel()
+
+    var editedPhoto = CIImage()
+    var sliderValue: Float?
+    var currentFilterIndex: Int?
+    var uiButtonCollection = [UIButton]()
+    var modeSelected: editingMode!
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        viewModel.view = self
+        inEditPhotoImageView.image = inEditPhoto
+
+        uiButtonCollection = [firstFilterButton,
+                              secondFilterButton,
+                              thirdFilterButton,
+                              fourthFIlterButton,
+                              fifthFilterButton]
+
+        setupAdjustButtons()
+    }
+
+    @IBAction func firstFilterButtonTapped(_ sender: Any) {
+        switch modeSelected {
+        case .manual:
+            currentFilterLabel.text = "VIBRANCE"
+        case .predefined:
+            currentFilterLabel.text = "CAMSHARE"
+            inEditPhotoImageView.image = fifthFilterButton.backgroundImage(for: .normal)
+            //viewModel.applyPredefinedFilter(image: inEditPhoto, selectedFilter: 0)
+        case .crop:
+            currentFilterLabel.isHidden = true
+        case .none:
+            currentFilterLabel.text = "Mode not avaialable"
+        }
+        currentFilterIndex = 0
+        filterChanged()
+    }
+
+    @IBAction func secondFilterButtonTapped(_ sender: Any) {
+        switch modeSelected {
+        case .manual:
+            currentFilterLabel.text = "EXPOSURE"
+        case .predefined:
+            currentFilterLabel.text = "COLD"
+            inEditPhotoImageView.image = secondFilterButton.backgroundImage(for: .normal)
+            //viewModel.applyPredefinedFilter(image: inEditPhoto, selectedFilter: 1)
+        case .crop:
+            currentFilterLabel.isHidden = true
+        case .none:
+            currentFilterLabel.text = "Mode not avaialable"
+        }
+        currentFilterIndex = 1
+        filterChanged()
+    }
+
+    @IBAction func thirdFilterButtonTapped(_ sender: Any) {
+        switch modeSelected {
+        case .manual:
+            currentFilterLabel.text = "GAMMA"
+        case .predefined:
+            currentFilterLabel.text = "VIVID COLD"
+            inEditPhotoImageView.image = thirdFilterButton.backgroundImage(for: .normal)
+            //viewModel.applyPredefinedFilter(image: inEditPhoto, selectedFilter: 2)
+        case .crop:
+            currentFilterLabel.isHidden = true
+        case .none:
+            currentFilterLabel.text = "Mode not avaialable"
+        }
+        currentFilterIndex = 2
+        filterChanged()
+    }
+
+    @IBAction func fourthFilterButtonTapped(_ sender: Any) {
+        switch modeSelected {
+        case .manual:
+            currentFilterLabel.text = "VIGNETTE"
+        case .predefined:
+            currentFilterLabel.text = "WARM"
+            inEditPhotoImageView.image = fourthFIlterButton.backgroundImage(for: .normal)
+            //viewModel.applyPredefinedFilter(image: inEditPhoto, selectedFilter: 3)
+        case .crop:
+            currentFilterLabel.isHidden = true
+        case .none:
+            currentFilterLabel.text = "Mode not avaialable"
+        }
+        currentFilterIndex = 3
+        filterChanged()
+    }
+
+    @IBAction func fifthFilterButtonTapped(_ sender: Any) {
+        switch modeSelected {
+        case .manual:
+            currentFilterLabel.text = "TINT"
+        case .predefined:
+            currentFilterLabel.text = "VIVID WARM"
+            inEditPhotoImageView.image = fifthFilterButton.backgroundImage(for: .normal)
+            //viewModel.applyPredefinedFilter(image: inEditPhoto, selectedFilter: 4)
+        case .crop:
+            currentFilterLabel.isHidden = true
+        case .none:
+            currentFilterLabel.text = "Mode not avaialable"
+        }
+        currentFilterIndex = 4
+        filterChanged()
+    }
+
+    @IBAction func sliderValueChanged(_ sender: Any) {
+        var value = applyAmountSlider.value - 0.5
+        value = value * 2
+        sliderValue = value
+        sliderValueLabel.text = String((value*100).rounded(.up))
+        
+        var ciImageCandidate = CIImage()
+        if let imageData = inEditPhoto.jpegData(compressionQuality: 1) {
+            ciImageCandidate = CIImage(data: imageData)!
+        }
+
+        switch currentFilterIndex {
+        case 0:
+            if #available(iOS 13.0, *) {
+                let filter = CIFilter.vibrance()
+                filter.amount = value
+                filter.inputImage = ciImageCandidate
+                inEditPhotoImageView.image = UIImage(ciImage: filter.outputImage!)
+            }
+        case 1:
+            if #available(iOS 13.0, *) {
+                let filter = CIFilter.exposureAdjust()
+                filter.ev = value
+                filter.inputImage = ciImageCandidate
+                inEditPhotoImageView.image = UIImage(ciImage: filter.outputImage!)
+            }
+        case 2:
+            if #available(iOS 13.0, *) {
+                let filter = CIFilter.gammaAdjust()
+                filter.power = value
+                filter.inputImage = ciImageCandidate
+                inEditPhotoImageView.image = UIImage(ciImage: filter.outputImage!)
+            }
+        case 3:
+            if #available(iOS 13.0, *) {
+                let filter = CIFilter.vignette()
+                filter.radius = 10
+                filter.intensity = value
+                filter.inputImage = ciImageCandidate
+                inEditPhotoImageView.image = UIImage(ciImage: filter.outputImage!)
+            }
+        case 4:
+            if #available(iOS 13.0, *) {
+                let filter = CIFilter.temperatureAndTint()
+                filter.inputImage = ciImageCandidate
+                value = value + 0.5
+                value = value*2
+                filter.neutral = CIVector(x: 6500, y: 0)
+                print("\(CIVector(x: CGFloat(value*10000), y: 0)) value: \(value)")
+                filter.targetNeutral = CIVector(x: CGFloat(value*10000), y: 0)
+                inEditPhotoImageView.image = UIImage(ciImage: filter.outputImage!)
+            }
+        default:
+            currentFilterLabel.text = "No Adjustment Selected"
+        }
+    }
+
+    @available(iOS 13.0, *)
+    @IBAction func manualEditingTapped(_ sender: Any) {
+        modeChanged(mode: editingMode.manual)
+        modeSelected = editingMode.manual
+    }
+
+    @available(iOS 13.0, *)
+    @IBAction func predefinedEditingTapped(_ sender: Any) {
+        modeChanged(mode: editingMode.predefined)
+        modeSelected = editingMode.predefined
+    }
+
+    @available(iOS 13.0, *)
+    @IBAction func cropEditingTapped(_ sender: Any) {
+        modeChanged(mode: editingMode.crop)
+        modeSelected = editingMode.crop
+    }
+
+    @IBAction func doneButtonTapped(_ sender: Any) {
+        
+        let alert = UIAlertController(title: "Export Image",
+                                      message: "Save image to photos ?", preferredStyle: .alert)
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { (_) in
+            guard let image = self.inEditPhotoImageView.image else {return}
+            guard let imageData = image.jpegData(compressionQuality: 1) else {return}
+            guard let newImage = UIImage(data: imageData) else {return}
+            UIImageWriteToSavedPhotosAlbum(newImage, self,
+                                           #selector(self.image(_:didFinishSavingWithError:contextInfo:)),
+                                           nil)
+        }))
+        present(alert, animated: true, completion: nil)
+    }
+    
+    @objc func image(_ image: UIImage, didFinishSavingWithError error: Error?, contextInfo: UnsafeRawPointer) {
+        if let error = error {
+            let alert = UIAlertController(title: "Save Error",
+                                          message: error.localizedDescription,
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+            present(alert, animated: true, completion: nil)
+        } else {
+            let alert = UIAlertController(title: "Success!",
+                                          message: "Your images is saved to photos.",
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+            present(alert, animated: true, completion: nil)
+        }
+    }
+    
+    func filterChanged() {
+        for index in 0..<uiButtonCollection.count {
+            if index == currentFilterIndex {
+                let button = uiButtonCollection[index]
+                button.layer.borderColor = UIColor.green.cgColor
+                button.layer.borderWidth = 2
+                button.tintColor = UIColor.green
+            } else {
+                let button = uiButtonCollection[index]
+                button.layer.borderColor = UIColor.darkGray.cgColor
+                button.layer.borderWidth = 2
+                button.tintColor = UIColor.white
+            }
+        }
+    }
+
+    func setupAdjustButtons() {
+        sliderValueLabel.text = String((applyAmountSlider.value).rounded(.up))
+        modeSelected = .manual
+        roundAndSetBackgroundColorButtons()
+        placeIconsOnAdjustButtons()
+    }
+    
+    func placeIconsOnAdjustButtons() {
+        firstFilterButton.setImage(UIImage(named: "Vibrance Icon"), for: .normal)
+        secondFilterButton.setImage(UIImage(named: "Exposure Icon"), for: .normal)
+        thirdFilterButton.setImage(UIImage(named: "Gamma Icon"), for: .normal)
+        fourthFIlterButton.setImage(UIImage(named: "Vignette Icon"), for: .normal)
+        fifthFilterButton.setImage(UIImage(named: "Tint Icon"), for: .normal)
+    }
+
+    func roundAndSetBackgroundColorButtons() {
+        for button in uiButtonCollection {
+            button.layer.cornerRadius = button.frame.size.width/2
+            button.layer.borderColor = UIColor.black.cgColor
+            button.layer.borderWidth = 2
+            button.layer.backgroundColor = UIColor.clear.cgColor
+        }
+    }
+
+    @available(iOS 13.0, *)
+    func modeChanged(mode: editingMode) {
+        switch mode {
+        case editingMode.manual:
+            currentFilterLabel.text = "ADJUST"
+            applyAmountSlider.alpha = 1
+            sliderValueLabel.alpha = 1
+            roundAndSetBackgroundColorButtons()
+        case editingMode.predefined:
+            currentFilterLabel.text = "CHOOSE A FILTER"
+            let thumbnails = [viewModel.createCamShareCustionFilter(image: inEditPhoto),
+                              viewModel.createColdFilter(image: inEditPhoto),
+                              viewModel.createColdVividFilter(image: inEditPhoto),
+                              viewModel.createWarmFilter(image: inEditPhoto),
+                              viewModel.createWarmVididFilter(image: inEditPhoto)]
+            for index in 0..<uiButtonCollection.count {
+                let button = uiButtonCollection[index]
+                button.setImage(.none, for: .normal)
+                button.setBackgroundImage(UIImage(ciImage: thumbnails[index]), for: .normal)
+                button.layer.cornerRadius = button.frame.size.width/4
+                button.layer.masksToBounds = true
+            }
+            applyAmountSlider.alpha = 0
+            sliderValueLabel.alpha = 0
+        case editingMode.crop:
+            currentFilterLabel.text = "CROP"
+        }
+    }
+}
+extension PhotoEditingViewController: PhotoEditorViewType {
+    func updateImageView(image: CIImage) {
+        inEditPhotoImageView.image = UIImage(ciImage: image)
+    }
+}
+
+enum editingMode {
+    case manual
+    case predefined
+    case crop
+}

--- a/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
+++ b/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
@@ -23,7 +23,7 @@ import CoreImage.CIFilterBuiltins
     @IBOutlet var adjustButton: UIBarButtonItem!
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var cropButton: UIBarButtonItem!
-    
+
     @objc public var inEditPhoto = UIImage(named: "image-2")!
     @objc public var name = ""
 
@@ -214,7 +214,7 @@ import CoreImage.CIFilterBuiltins
         
         let alert = UIAlertController(title: "Export Image",
                                       message: "Save image to photos ?", preferredStyle: .alert)
-        
+
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { (_) in
             guard let image = self.inEditPhotoImageView.image else {return}
@@ -226,7 +226,7 @@ import CoreImage.CIFilterBuiltins
         }))
         present(alert, animated: true, completion: nil)
     }
-    
+
     @objc func image(_ image: UIImage, didFinishSavingWithError error: Error?, contextInfo: UnsafeRawPointer) {
         if let error = error {
             let alert = UIAlertController(title: "Save Error",

--- a/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
+++ b/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
@@ -8,9 +8,9 @@
 import UIKit
 import CoreImage
 import CoreImage.CIFilterBuiltins
-
+//swiftlint:disable all
 @objcMembers public class PhotoEditingViewController: UIViewController {
-
+//swiftlint:enable all
     @IBOutlet var inEditPhotoImageView: UIImageView!
     @IBOutlet var currentFilterLabel: UILabel!
     @IBOutlet var firstFilterButton: UIButton!
@@ -33,7 +33,7 @@ import CoreImage.CIFilterBuiltins
     var sliderValue: Float?
     var currentFilterIndex: Int?
     var uiButtonCollection = [UIButton]()
-    var modeSelected: editingMode!
+    var modeSelected: EditingMode!
 
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -133,7 +133,7 @@ import CoreImage.CIFilterBuiltins
         currentFilterIndex = 4
         filterChanged()
     }
-
+    //swiftlint:disable all
     @IBAction func sliderValueChanged(_ sender: Any) {
         var value = applyAmountSlider.value - 0.5
         value = value * 2
@@ -179,8 +179,8 @@ import CoreImage.CIFilterBuiltins
             if #available(iOS 13.0, *) {
                 let filter = CIFilter.temperatureAndTint()
                 filter.inputImage = ciImageCandidate
-                value = value + 0.5
-                value = value*2
+                value += 0.5
+                value *= 2
                 filter.neutral = CIVector(x: 6500, y: 0)
                 print("\(CIVector(x: CGFloat(value*10000), y: 0)) value: \(value)")
                 filter.targetNeutral = CIVector(x: CGFloat(value*10000), y: 0)
@@ -189,24 +189,25 @@ import CoreImage.CIFilterBuiltins
         default:
             currentFilterLabel.text = "No Adjustment Selected"
         }
+    //swiftlint:enable all
     }
 
     @available(iOS 13.0, *)
     @IBAction func manualEditingTapped(_ sender: Any) {
-        modeChanged(mode: editingMode.manual)
-        modeSelected = editingMode.manual
+        modeChanged(mode: EditingMode.manual)
+        modeSelected = EditingMode.manual
     }
 
     @available(iOS 13.0, *)
     @IBAction func predefinedEditingTapped(_ sender: Any) {
-        modeChanged(mode: editingMode.predefined)
-        modeSelected = editingMode.predefined
+        modeChanged(mode: EditingMode.predefined)
+        modeSelected = EditingMode.predefined
     }
 
     @available(iOS 13.0, *)
     @IBAction func cropEditingTapped(_ sender: Any) {
-        modeChanged(mode: editingMode.crop)
-        modeSelected = editingMode.crop
+        modeChanged(mode: EditingMode.crop)
+        modeSelected = EditingMode.crop
     }
 
     @IBAction func doneButtonTapped(_ sender: Any) {
@@ -264,7 +265,7 @@ import CoreImage.CIFilterBuiltins
         roundAndSetBackgroundColorButtons()
         placeIconsOnAdjustButtons()
     }
-    
+
     func placeIconsOnAdjustButtons() {
         firstFilterButton.setImage(UIImage(named: "Vibrance Icon"), for: .normal)
         secondFilterButton.setImage(UIImage(named: "Exposure Icon"), for: .normal)
@@ -283,14 +284,14 @@ import CoreImage.CIFilterBuiltins
     }
 
     @available(iOS 13.0, *)
-    func modeChanged(mode: editingMode) {
+    func modeChanged(mode: EditingMode) {
         switch mode {
-        case editingMode.manual:
+        case EditingMode.manual:
             currentFilterLabel.text = "ADJUST"
             applyAmountSlider.alpha = 1
             sliderValueLabel.alpha = 1
             roundAndSetBackgroundColorButtons()
-        case editingMode.predefined:
+        case EditingMode.predefined:
             currentFilterLabel.text = "CHOOSE A FILTER"
             let thumbnails = [viewModel.createCamShareCustionFilter(image: inEditPhoto),
                               viewModel.createColdFilter(image: inEditPhoto),
@@ -306,7 +307,7 @@ import CoreImage.CIFilterBuiltins
             }
             applyAmountSlider.alpha = 0
             sliderValueLabel.alpha = 0
-        case editingMode.crop:
+        case EditingMode.crop:
             currentFilterLabel.text = "CROP"
         }
     }
@@ -317,7 +318,7 @@ extension PhotoEditingViewController: PhotoEditorViewType {
     }
 }
 
-enum editingMode {
+enum EditingMode {
     case manual
     case predefined
     case crop

--- a/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
+++ b/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
@@ -182,7 +182,6 @@ import CoreImage.CIFilterBuiltins
                 value += 0.5
                 value *= 2
                 filter.neutral = CIVector(x: 6500, y: 0)
-                print("\(CIVector(x: CGFloat(value*10000), y: 0)) value: \(value)")
                 filter.targetNeutral = CIVector(x: CGFloat(value*10000), y: 0)
                 inEditPhotoImageView.image = UIImage(ciImage: filter.outputImage!)
             }

--- a/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
+++ b/camPod/Classes/EditPhoto/View/PhotoEditingViewController.swift
@@ -139,7 +139,7 @@ import CoreImage.CIFilterBuiltins
         value = value * 2
         sliderValue = value
         sliderValueLabel.text = String((value*100).rounded(.up))
-        
+
         var ciImageCandidate = CIImage()
         if let imageData = inEditPhoto.jpegData(compressionQuality: 1) {
             ciImageCandidate = CIImage(data: imageData)!
@@ -211,7 +211,7 @@ import CoreImage.CIFilterBuiltins
     }
 
     @IBAction func doneButtonTapped(_ sender: Any) {
-        
+
         let alert = UIAlertController(title: "Export Image",
                                       message: "Save image to photos ?", preferredStyle: .alert)
 

--- a/camPod/Classes/EditPhoto/View/PhotoEditorViewType.swift
+++ b/camPod/Classes/EditPhoto/View/PhotoEditorViewType.swift
@@ -1,0 +1,12 @@
+//
+//  PhotoEditorViewType.swift
+//  camPod
+//
+//  Created by Janco Erasmus on 2020/04/21.
+//
+
+import Foundation
+
+protocol PhotoEditorViewType {
+    func updateImageView(image: CIImage)
+}

--- a/camPod/Classes/SelectedImage/View/SelectedImageObjCViewController.m
+++ b/camPod/Classes/SelectedImage/View/SelectedImageObjCViewController.m
@@ -6,6 +6,9 @@
 //
 
 #import "SelectedImageObjCViewController.h"
+#import "camPod-umbrella.h"
+#import "camPod-Swift.h"
+#import "Pods-camshare-umbrella.h"
 
 @interface SelectedImageObjCViewController ()
 @property (strong, nonatomic) IBOutlet UIImageView *selectedImageImageView;
@@ -15,7 +18,22 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    UIBarButtonItem *editButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem: UIBarButtonSystemItemEdit target:self action:@selector(editTapped)];
+    self.navigationItem.rightBarButtonItem = editButton;
+    
     self.selectedImageImageView.image = self.selectedImage;
+}
+
+-(void) editTapped {
+    [self performSegueWithIdentifier:@"photoEditor" sender:self];
+}
+
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    if ([[segue identifier] isEqualToString:@"photoEditor"]) {
+        PhotoEditingViewController *photoEditViewController = (PhotoEditingViewController*)[segue destinationViewController];
+        photoEditViewController.inEditPhoto = self.selectedImageImageView.image;
+    }
 }
 
 @end


### PR DESCRIPTION
## Photo Edit Feature
User can now edit photos in their album and save them to their camera roll.
Feature mostly iOS 13 drivin.

### Adjust Photo
- User can choose 5 adjustment options.
- Available adjustments: Vibrance - Exposure - Gamma - Vignette - Tint.

### Filter Photo
- There is 5 predefined filters. 
- Available Filters: CamShare - Cold - Vivid Cold - Warm - Vivid Warm.
- CamShare is an App Custom filter.

### Saving Image
- Exporting the image will save it to the user's camera roll.
- Does not effect the photo in the app; Feature to be added.

### Images

![IMG_3271](https://user-images.githubusercontent.com/60605366/80093508-eac19380-8564-11ea-90af-deb7576da918.PNG)

![IMG_3273](https://user-images.githubusercontent.com/60605366/80093528-f44afb80-8564-11ea-9495-4ba5e4d27c6e.PNG)

![IMG_3274](https://user-images.githubusercontent.com/60605366/80093545-f90faf80-8564-11ea-8d46-75392a5509f6.PNG)

![IMG_3278](https://user-images.githubusercontent.com/60605366/80093556-fd3bcd00-8564-11ea-8f13-c2c76869447d.PNG)
